### PR TITLE
iOS app crash when set ItemSource in modal page

### DIFF
--- a/AutoSuggestBox/Platform/NativeAutoSuggestBox.iOS.cs
+++ b/AutoSuggestBox/Platform/NativeAutoSuggestBox.iOS.cs
@@ -189,12 +189,16 @@ namespace dotMorten.Xamarin.Forms.Platform.iOS
                 var viewController = InputTextField.Window?.RootViewController;
                 if (viewController == null)
                     return;
-                if (viewController.ModalViewController != null)
-                    viewController = viewController.ModalViewController;
+                if (viewController.PresentedViewController != null)
+                    viewController = viewController.PresentedViewController;
                 if (SelectionList.Superview == null)
                 {
                     viewController.Add(SelectionList);
                 }
+
+                if (SelectionList.Window == null)
+                   InputTextField.Window.Add(SelectionList);
+
                 SelectionList.TopAnchor.ConstraintEqualTo(InputTextField.BottomAnchor).Active = true;
                 SelectionList.LeftAnchor.ConstraintEqualTo(InputTextField.LeftAnchor).Active = true;
                 SelectionList.WidthAnchor.ConstraintEqualTo(InputTextField.WidthAnchor).Active = true;


### PR DESCRIPTION
So, the problem was reproduced.

In some layouts, when opening a page modally, the SelectionList element is not embedded in the window hierarchy and does not apply to any window => the specified constraints cannot be satisfied and the application crashes when trying to change the ItemsSource.

This fix solves this problem.